### PR TITLE
Correct span id for paths

### DIFF
--- a/handlebars/partials/swagger/path.hbs
+++ b/handlebars/partials/swagger/path.hbs
@@ -6,7 +6,7 @@
     @api public
 --}}
 
-<span id="path-{{path}}"></span>
+<span id="path-{{htmlId path}}"></span>
 {{#eachSorted pathItems}}
     {{>swagger/operation . operation=. method=@key path=../path}}
 {{/eachSorted}}


### PR DESCRIPTION
The span id for paths was invalid as it isn't processed with `htmlId`. This applies the same processing as is used in `summary.hbs`.