### PR TITLE
Definitions should expose the schema in the model param

### DIFF
--- a/handlebars/partials/swagger/definitions.hbs
+++ b/handlebars/partials/swagger/definitions.hbs
@@ -7,5 +7,5 @@
 <h2>Definitions</h2>
 
 {{#each definitions}}
-    {{>swagger/model schema=. title=@key anchor="/definitions" }}
+    {{>swagger/model model=. title=@key anchor="/definitions" }}
 {{/each}}

--- a/handlebars/partials/swagger/model.hbs
+++ b/handlebars/partials/swagger/model.hbs
@@ -7,5 +7,5 @@
 
 {{! "title" is usually past as parameter, call the json-schema partials if necessary}}
 {{#if model}}
-    {{>json-schema/main-panel model title=title}}
+    {{>json-schema/main-panel model title=title anchor=anchor}}
 {{/if}}

--- a/handlebars/partials/swagger/responses.hbs
+++ b/handlebars/partials/swagger/responses.hbs
@@ -26,10 +26,10 @@
                             {{md description}}
                         </div>
                         <section class="visible-xs visible-sm">
-                            {{>swagger/model schema}}
+                            {{>swagger/model model=schema}}
                         </section>
                     </td>
-                    <td class="hidden-xs hidden-sm">{{>swagger/model schema}}</td>
+                    <td class="hidden-xs hidden-sm">{{>swagger/model model=schema}}</td>
                 </tr>
             {{/each}}
             </tbody>


### PR DESCRIPTION
This is what model.hbs expects. At the moment we get an empty definitions section.