### PR TITLE
Add HTTP status codes declared in some other RFCs.

### DIFF
--- a/handlebars/helpers.js
+++ b/handlebars/helpers.js
@@ -10,7 +10,8 @@ module.exports = {
   },
   'swagger--response-code': function (code) {
     // Comments refer to the section number in rfc2616
-    // If no section number specified, it's documented in other rfcs.
+    // If an rfc number is specified, the code is 
+    // documented in the specified rfc.
     return {
       '100': 'Continue', // 10.1.1
       '101': 'Switching Protocols', // 10.1.2
@@ -21,9 +22,9 @@ module.exports = {
       '204': 'No Content', // 10.2.5
       '205': 'Reset Content', // 10.2.6
       '206': 'Partial Content', // 10.2.7
-      '207': 'Multi-status',
-      '208': 'Already Reported',
-      '226': 'IM Used',
+      '207': 'Multi-status', // rfc4918, 11.1
+      '208': 'Already Reported', // rfc5842, 7.1
+      '226': 'IM Used', // rfc3229, 10.4.1
       '300': 'Multiple Choices', // 10.3.1
       '301': 'Moved Permanently', // 10.3.2
       '302': 'Found', // 10.3.3
@@ -50,14 +51,14 @@ module.exports = {
       '415': 'Unsupported Media Type', // 10.4.16
       '416': 'Requested Range Not Satisfiable', // 10.4.17
       '417': 'Expectation Failed', // 10.4.18
-      '421': 'Misdirected Request',
-      '422': 'Unprocessable Entity',
-      '423': 'Locked',
-      '424': 'Failed Dependency',
-      '426': 'Upgrade Required',
-      '428': 'Precondition Required',
-      '429': 'Too Many Requests',
-      '431': 'Request Header Fields Too Large',
+      '421': 'Misdirected Request', // rfc7540, 9.1.2
+      '422': 'Unprocessable Entity', // rfc4918, 11.2
+      '423': 'Locked', // rfc4918, 11.3
+      '424': 'Failed Dependency', // rfc4918, 11.4
+      '426': 'Upgrade Required', // rfc2817, 6
+      '428': 'Precondition Required', // rfc6585, 3
+      '429': 'Too Many Requests', // rfc6585, 4
+      '431': 'Request Header Fields Too Large', // rfc6585, 5
       '500': 'Internal Server Error', // 10.5.1
       '501': 'Not Implemented', // 10.5.2
       '502': 'Bad Gateway', // 10.5.3
@@ -65,10 +66,10 @@ module.exports = {
       '504': 'Gateway Timeout', // 10.5.5
       '505': 'HTTP Version Not Supported', // 10.5.6
       '506': 'Variant Also Negotiates',
-      '507': 'Insufficient Storage',
-      '508': 'Loop Detected',
-      '510': 'Not Extended',
-      '511': 'Network Authentication Required'
+      '507': 'Insufficient Storage', // rfc4918, 11.5
+      '508': 'Loop Detected', // rfc5842, 7.2
+      '510': 'Not Extended', // rfc2774, 7
+      '511': 'Network Authentication Required' // rfc6585, 6
     }[code]
   }
 }

--- a/handlebars/helpers.js
+++ b/handlebars/helpers.js
@@ -10,6 +10,7 @@ module.exports = {
   },
   'swagger--response-code': function (code) {
     // Comments refer to the section number in rfc2616
+    // If no section number specified, it's documented in other rfcs.
     return {
       '100': 'Continue', // 10.1.1
       '101': 'Switching Protocols', // 10.1.2
@@ -20,6 +21,9 @@ module.exports = {
       '204': 'No Content', // 10.2.5
       '205': 'Reset Content', // 10.2.6
       '206': 'Partial Content', // 10.2.7
+      '207': 'Multi-status',
+      '208': 'Already Reported',
+      '226': 'IM Used',
       '300': 'Multiple Choices', // 10.3.1
       '301': 'Moved Permanently', // 10.3.2
       '302': 'Found', // 10.3.3
@@ -46,12 +50,25 @@ module.exports = {
       '415': 'Unsupported Media Type', // 10.4.16
       '416': 'Requested Range Not Satisfiable', // 10.4.17
       '417': 'Expectation Failed', // 10.4.18
+      '421': 'Misdirected Request',
+      '422': 'Unprocessable Entity',
+      '423': 'Locked',
+      '424': 'Failed Dependency',
+      '426': 'Upgrade Required',
+      '428': 'Precondition Required',
+      '429': 'Too Many Requests',
+      '431': 'Request Header Fields Too Large',
       '500': 'Internal Server Error', // 10.5.1
       '501': 'Not Implemented', // 10.5.2
       '502': 'Bad Gateway', // 10.5.3
       '503': 'Service Unavailable', // 10.5.4
       '504': 'Gateway Timeout', // 10.5.5
-      '505': 'HTTP Version Not Supported' // 10.5.6
+      '505': 'HTTP Version Not Supported', // 10.5.6
+      '506': 'Variant Also Negotiates',
+      '507': 'Insufficient Storage',
+      '508': 'Loop Detected',
+      '510': 'Not Extended',
+      '511': 'Network Authentication Required'
     }[code]
   }
 }

--- a/handlebars/helpers.js
+++ b/handlebars/helpers.js
@@ -10,7 +10,7 @@ module.exports = {
   },
   'swagger--response-code': function (code) {
     // Comments refer to the section number in rfc2616
-    // If an rfc number is specified, the code is 
+    // If an rfc number is specified, the code is
     // documented in the specified rfc.
     return {
       '100': 'Continue', // 10.1.1


### PR DESCRIPTION
Hi Nils,

I like your work! I am using it for my course group project. I find the helper.js file misses some new status codes, including the "422 Unprocessable Entity" commonly for validation failures. Therefore, I add the status codes specified in other RFCs than 2616 to helper.js; for those defined by companies and not in any RFC, I do not add them.

Thanks,
Xi